### PR TITLE
Only create SSH folder if it does not already exist

### DIFF
--- a/scripts/initialize_gopass.sh
+++ b/scripts/initialize_gopass.sh
@@ -11,7 +11,7 @@ set -e
 
 function initialize_ssh {
 #initialize ssh to checkout secret store
-mkdir $HOME/.ssh
+mkdir -p $HOME/.ssh
 cp ssh-key/identity $HOME/.ssh/id_rsa
 chmod 700 $HOME/.ssh
 chmod 600 $HOME/.ssh/id_rsa


### PR DESCRIPTION
In my kubernetes deployment I mount the known_hosts file into the .ssh folder. So kubernetes already creates it. This currently produces the following error: `cannot create directory '/home/argocd/.ssh': File exists`